### PR TITLE
removing uniqueness constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # donor_details
-ArchivesSpace plugin that adds donor details to agents. 
+ArchivesSpace plugin that adds donor details to agents.
 
-Currently only includes donor numbers.
+Currently includes donor numbers and DART ID.
 
 Acknowledgements
 ----------------

--- a/version_1.1.2/backend/model/donor_detail.rb
+++ b/version_1.1.2/backend/model/donor_detail.rb
@@ -15,10 +15,4 @@ class DonorDetail < Sequel::Model(:donor_detail)
 			},
 			:only_if => proc { |json| json["number_auto_generate"]}
 
-  def validate
-    super
-    validates_unique(:number, :message => "Donor number must be unique")
-  end
-
-
 end

--- a/version_1.1.2/frontend/locales/en.yml
+++ b/version_1.1.2/frontend/locales/en.yml
@@ -7,6 +7,3 @@ en:
     _frontend:
       action:
         add: Add Donor Detail
-
-  validation_errors:
-    donor_number_must_be_unique: Donor number must be unique

--- a/version_1.1.2/migrations/001_donor_detail.rb
+++ b/version_1.1.2/migrations/001_donor_detail.rb
@@ -27,7 +27,6 @@ Sequel.migration do
       add_foreign_key([:agent_family_id], :agent_family, :key => :id)
       add_foreign_key([:agent_corporate_entity_id], :agent_corporate_entity, :key => :id)
       add_foreign_key([:agent_software_id], :agent_software, :key => :id)
-      add_unique_constraint(:number, :name => "donor_number_uniq")
     end
 
   end

--- a/version_1.2.0/backend/model/donor_detail.rb
+++ b/version_1.2.0/backend/model/donor_detail.rb
@@ -15,10 +15,5 @@ class DonorDetail < Sequel::Model(:donor_detail)
 			},
 			:only_if => proc { |json| json["number_auto_generate"]}
 
-  def validate
-    super
-    validates_unique(:number, :message => "Donor number must be unique")
-  end
-
 
 end

--- a/version_1.2.0/frontend/locales/en.yml
+++ b/version_1.2.0/frontend/locales/en.yml
@@ -7,6 +7,3 @@ en:
     _frontend:
       action:
         add: Add Donor Detail
-
-  validation_errors:
-    donor_number_must_be_unique: Donor number must be unique

--- a/version_1.2.0/migrations/001_donor_detail.rb
+++ b/version_1.2.0/migrations/001_donor_detail.rb
@@ -27,7 +27,6 @@ Sequel.migration do
       add_foreign_key([:agent_family_id], :agent_family, :key => :id)
       add_foreign_key([:agent_corporate_entity_id], :agent_corporate_entity, :key => :id)
       add_foreign_key([:agent_software_id], :agent_software, :key => :id)
-      add_unique_constraint(:number, :name => "donor_number_uniq")
     end
 
   end

--- a/version_1.3.0/backend/model/donor_detail.rb
+++ b/version_1.3.0/backend/model/donor_detail.rb
@@ -15,10 +15,4 @@ class DonorDetail < Sequel::Model(:donor_detail)
 			},
 			:only_if => proc { |json| json["number_auto_generate"]}
 
-  def validate
-    super
-    validates_unique(:number, :message => "Donor number must be unique")
-  end
-
-
 end

--- a/version_1.3.0/frontend/locales/en.yml
+++ b/version_1.3.0/frontend/locales/en.yml
@@ -1,12 +1,9 @@
 en:
   donor_detail:
     number: Donor Number
-    dart_id: DART ID
+    dart_id: DART LID
     _plural: Donor Details
     _singular: Donor Detail
     _frontend:
       action:
         add: Add Donor Detail
-
-  validation_errors:
-    donor_number_must_be_unique: Donor number must be unique

--- a/version_1.3.0/migrations/001_donor_detail.rb
+++ b/version_1.3.0/migrations/001_donor_detail.rb
@@ -27,7 +27,6 @@ Sequel.migration do
       add_foreign_key([:agent_family_id], :agent_family, :key => :id)
       add_foreign_key([:agent_corporate_entity_id], :agent_corporate_entity, :key => :id)
       add_foreign_key([:agent_software_id], :agent_software, :key => :id)
-      add_unique_constraint(:number, :name => "donor_number_uniq")
     end
 
   end


### PR DESCRIPTION
We have a lot of donors with the same donor number, so a uniqueness constraint is not feasible.

Going forward, auto-generating a donor number will ensure that all donor numbers are unique, although the uniqueness will not be validated. 
