### PR TITLE
add donor number to agent_links section

### DIFF
--- a/frontend/views/linked_agents/_show.html.erb
+++ b/frontend/views/linked_agents/_show.html.erb
@@ -1,0 +1,69 @@
+<%
+   section_id = "linked_agent" if section_id.blank?
+   relator_enumeration = "linked_agent_archival_record_relators" if relator_enumeration.nil?
+%>
+
+<section id="<%= section_id %>" class="subrecord-form-dummy">
+  <h3><%= I18n.t("linked_agent._plural") %></h3>
+  <div class="subrecord-form-container">
+    <div class="subrecord-form-fields">
+      <table class="table table-striped table-bordered table-condensed table-hover token-list">
+        <thead>
+          <tr>
+            <td class="col-md-2"><%= I18n.t("linked_agent.role") %></td>
+            <td class="col-md-2"><%= I18n.t("donor_detail.donor_number") %></td>
+            <td class="col-md-4"><%= I18n.t("linked_agent.ref") %></td>
+            <td class="col-md-4"></td>
+          </tr>
+        </thead>
+        <tbody>
+          <% linked_agents.each_with_index do | link, index | %>
+            <tr>
+              <td>
+                <%= I18n.t("enumerations.linked_agent_role.#{link["role"]}", :default => link["role"]) %>
+              </td>
+              <td>
+                <!-- hack to remove the relator without removing the code -->
+                <% if false %> 
+                  <% if link["relator"] %>
+                    <%= I18n.t("enumerations.#{relator_enumeration}.#{link["relator"]}", :default => link["relator"]) %>
+                  <% end %>
+                <% end %>
+
+                <!-- add the donor number instead -->
+                <% if !ASUtils.wrap(link["_resolved"]["donor_details"]).empty? %>
+                  <%= link["_resolved"]["donor_details"][0]["donor_number"] %>
+                <% end %>                
+              </td>
+              <td class="token-list">
+                <%= render_token :object => link,
+                                 :label => link["_resolved"]["title"],
+                                 :type => link["_resolved"]["agent_type"],
+                                 :uri => link["_resolved"]["uri"] %>
+              </td>
+              <td>
+                <dl>
+                  <% if !ASUtils.wrap(link['terms']).empty? %>
+                    <dt><%= I18n.t("linked_agent.terms") %></dt>
+
+                    <% ASUtils.wrap(link['terms']).each do |term| %>
+                      <dd class="label label-info" title="<%= I18n.t("enumerations.subject_term_type.#{term["term_type"]}") %>">
+                        <%= term['term'] %>
+                      </dd>
+                    <% end %>
+                  <% end %>
+
+                  <% if link['title'] %>
+                    <dt><%= I18n.t("linked_agent.title") %></dt>
+                    <dd><%= link['title'] %></dd>
+                  <% end %>
+                </dl>
+
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Displays the donor number for an agent rather than the Relator in the Agent Links section when looking at a record in view mode.